### PR TITLE
Unified responses

### DIFF
--- a/common/exceptions.py
+++ b/common/exceptions.py
@@ -1,10 +1,12 @@
-from rest_framework.exceptions import APIException
+from rest_framework.exceptions import APIException as _APIException
 
 
-class SluglineAPIException(APIException):
-    def __init__(self, detail):
-        super().__init__(detail={
-            'success': False,
-            'error': [detail] if isinstance(detail, str) else detail
-        })
+class APIException(_APIException):
+    def __init__(self, detail, **kwargs):
+        if isinstance(detail, str) or isinstance(detail, list):
+            super().__init__(detail={
+                'detail': [detail] if isinstance(detail, str) else detail
+            }, **kwargs)
+        else:
+            super().__init__(detail=detail, **kwargs)
 

--- a/common/pagination.py
+++ b/common/pagination.py
@@ -1,10 +1,7 @@
 from rest_framework.pagination import LimitOffsetPagination
-from rest_framework.response import Response
+from common.response import Response
 
 
 class SluglinePagination(LimitOffsetPagination):
     def get_paginated_response(self, data):
-        return Response({
-            'success': True,
-            'data': super(SluglinePagination, self).get_paginated_response(data).data
-        })
+        return Response(super(SluglinePagination, self).get_paginated_response(data).data)

--- a/common/renderers.py
+++ b/common/renderers.py
@@ -1,0 +1,10 @@
+from rest_framework.renderers import JSONRenderer
+
+
+class SluglineRenderer(JSONRenderer):
+    def render(self, data, accepted_media_type=None, renderer_context=None):
+        rendered_json = {
+            'success': True,
+            **{k: v for k, v in data.items() if v is not None}
+        }
+        return super().render(rendered_json, accepted_media_type=accepted_media_type, renderer_context=renderer_context)

--- a/common/response.py
+++ b/common/response.py
@@ -1,0 +1,9 @@
+from rest_framework.response import Response as _Response
+
+
+class Response(_Response):
+    def __init__(self, data=None, success=True, **kwargs):
+        super().__init__(data={
+            'success': success,
+            'data': data
+        }, **kwargs)

--- a/common/views.py
+++ b/common/views.py
@@ -1,0 +1,14 @@
+from rest_framework.views import exception_handler
+
+
+def slugline_exception_handler(exc, context):
+    response = exception_handler(exc, context)
+
+    if response is not None:
+        arrayified_errors = {k: [v] if isinstance(v, str) else v for k, v in response.data.items()}
+        response.data = {
+            'success': False,
+            'error': arrayified_errors
+        }
+
+    return response

--- a/content/views.py
+++ b/content/views.py
@@ -4,14 +4,13 @@ from django.http import Http404
 from django.db.models.functions import Length
 from rest_framework.viewsets import ModelViewSet
 from rest_framework.decorators import action
-from rest_framework.response import Response
 
+from common.response import Response
 from content.models import Issue, Article
 from content.serializers import IssueSerializer, ArticleSerializer
 
 
 class IssueViewSet(ModelViewSet):
-
     queryset = Issue.objects.all()
     serializer_class = IssueSerializer
 
@@ -25,7 +24,7 @@ class IssueViewSet(ModelViewSet):
         issue_articles = Article.objects.filter(issue__pk=pk)
         return Response(ArticleSerializer(issue_articles, many=True).data)
 
-class ArticleViewSet(ModelViewSet):
 
+class ArticleViewSet(ModelViewSet):
     queryset = Article.objects.all()
     serializer_class = ArticleSerializer

--- a/slugline/settings.py
+++ b/slugline/settings.py
@@ -151,5 +151,10 @@ MEDIA_URL = '/media/'
 
 REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'common.pagination.SluglinePagination',
-    'PAGE_SIZE': 10
+    'PAGE_SIZE': 10,
+    'EXCEPTION_HANDLER': 'common.views.slugline_exception_handler',
+    'DEFAULT_RENDERER_CLASSES': [
+        'common.renderers.SluglineRenderer',
+        'rest_framework.renderers.BrowsableAPIRenderer'
+    ]
 }

--- a/user/models.py
+++ b/user/models.py
@@ -21,6 +21,12 @@ class SluglineUser(AbstractUser):
         """Is this user an editor?"""
         return self.groups.filter(name='Editor').exists()
 
+    # We write a setter as we construct temporary users when doing password validation, and sometimes editor information
+    # is part of the data.
+    @is_editor.setter
+    def is_editor(self, value):
+        pass
+
 
 class UserSerializer(serializers.ModelSerializer):
     is_editor = serializers.BooleanField(default=False)

--- a/user/urls.py
+++ b/user/urls.py
@@ -9,6 +9,6 @@ router.register('users', UserViewSet, 'users')
 urlpatterns = [
     path('login/', login_view),
     path('logout/', logout_view),
-    path('me/', single_user_view),
+    path('me/', current_user_view),
     *router.urls
 ]

--- a/user/urls.py
+++ b/user/urls.py
@@ -9,7 +9,6 @@ router.register('users', UserViewSet, 'users')
 urlpatterns = [
     path('login/', login_view),
     path('logout/', logout_view),
-    path('me/', retrieve_user_view),
-    path('me/', update_user_view),
+    path('me/', single_user_view),
     *router.urls
 ]

--- a/user/views.py
+++ b/user/views.py
@@ -60,7 +60,7 @@ def update_user(user, request):
 
 
 @api_view(['GET', 'PATCH'])
-def single_user_view(request):
+def current_user_view(request):
     is_authenticated = IsAuthenticated().has_permission(request, None)
     if request.method == 'GET':
         if is_authenticated:


### PR DESCRIPTION
API responses are now guaranteed to have a `success` field. If they are successful, they may optionally have a `data` field. If they are not, they may optionally have an `error` field. All exceptions will automatically have `success: False`.

This PR also introduces a custom Response class to simplify creating responses. It can be found in `common.response`.

See UWmathnews/slugline-web#4 for the corresponding front-end PR.