### PR TITLE
Refactor permissions system

### DIFF
--- a/common/permissions.py
+++ b/common/permissions.py
@@ -35,12 +35,34 @@ def create_permission(read_perm, write_perm):
     return NewPermission
 
 
-class IsContributorOrAbove(BasePermission):
+class SluglinePermission(BasePermission):
+    """
+    A BasePermission that implements has_object_permission properly.
+
+    DRF's version just returns True by default, which creates problems when we compose
+    a regular permission and an object permission.
+    """
+
+    def has_object_permission(self, request, view, obj):
+        return self.has_permission(request, view)
+
+
+class IsAuthenticated(SluglinePermission):
+    """
+    A copy of DRF's IsAuthenticated that, by virtue of inheriting from SluglinePermission,
+    handles has_object_permission properly.
+    """
+
+    def has_permission(self, request, view):
+        return bool(request.user and request.user.is_authenticated)
+
+
+class IsContributorOrAbove(SluglinePermission):
     def has_permission(self, request, view):
         return bool(isinstance(request.user, SluglineUser) or request.user.is_staff)
 
 
-class IsCopyeditorOrAbove(BasePermission):
+class IsCopyeditorOrAbove(SluglinePermission):
     def has_permission(self, request, view):
         return bool(
             isinstance(request.user, SluglineUser)
@@ -48,7 +70,7 @@ class IsCopyeditorOrAbove(BasePermission):
         )
 
 
-class IsEditorOrAbove(BasePermission):
+class IsEditorOrAbove(SluglinePermission):
     def has_permission(self, request, view):
         return bool(
             isinstance(request.user, SluglineUser)

--- a/common/permissions.py
+++ b/common/permissions.py
@@ -1,7 +1,25 @@
 from user.groups import COPYEDITOR_GROUP, EDITOR_GROUP
-from rest_framework.permissions import BasePermission
+from rest_framework.permissions import BasePermission, SAFE_METHODS
 
 from user.models import SluglineUser
+
+
+class SluglinePermission(BasePermission):
+    def __init__(self, read_perm, write_perm):
+        self.read_perm = read_perm
+        self.write_perm = write_perm
+
+    def has_permission(self, request, view):
+        if request.method in SAFE_METHODS:
+            return self.read_perm.has_permission(request, view)
+        else:
+            return self.write_perm.has_permission(request, view)
+
+    def has_object_permission(self, request, view, obj):
+        if request.method in SAFE_METHODS:
+            return self.read_perm.has_permission(request, view, obj)
+        else:
+            return self.write_perm.has_permission(request, view, obj)
 
 
 class IsContributorOrAbove(BasePermission):

--- a/content/permissions.py
+++ b/content/permissions.py
@@ -1,8 +1,5 @@
 from common.permissions import SluglinePermission
 
-from user.models import SluglineUser
-from user.groups import EDITOR_GROUP, CONTRIBUTOR_GROUP, COPYEDITOR_GROUP
-
 
 class IsArticlePublished(SluglinePermission):
     def has_object_permission(self, request, view, article):

--- a/content/permissions.py
+++ b/content/permissions.py
@@ -1,47 +1,14 @@
-from rest_framework import permissions
+from common.permissions import SluglinePermission
 
 from user.models import SluglineUser
 from user.groups import EDITOR_GROUP, CONTRIBUTOR_GROUP, COPYEDITOR_GROUP
 
 
-class IsPublishedOrIsAuthenticated(permissions.BasePermission):
+class IsArticlePublished(SluglinePermission):
     def has_object_permission(self, request, view, article):
-        return article.published or request.user.is_authenticated
+        return article.published
 
 
-class IsArticleOwnerOrReadOnly(IsPublishedOrIsAuthenticated):
+class IsArticleOwner(SluglinePermission):
     def has_object_permission(self, request, view, article):
-        if request.method in permissions.SAFE_METHODS:
-            return super().has_object_permission(request, view, article)
-        else:
-            return article.user == request.user
-
-
-class IsCopyeditorOrAboveOrReadOnly(IsPublishedOrIsAuthenticated):
-    def has_permission(self, request, view):
-        if request.method in permissions.SAFE_METHODS:
-            return True
-        else:
-            return isinstance(request.user, SluglineUser) and request.user.at_least(
-                COPYEDITOR_GROUP
-            )
-
-
-class IsEditorOrReadOnly(IsPublishedOrIsAuthenticated):
-    def has_permission(self, request, view):
-        if request.method in permissions.SAFE_METHODS:
-            return True
-        else:
-            return isinstance(request.user, SluglineUser) and request.user.at_least(
-                EDITOR_GROUP
-            )
-
-
-class IsEditorOrIsAuthenticatedReadOnly(IsPublishedOrIsAuthenticated):
-    def has_permission(self, request, view):
-        if request.method in permissions.SAFE_METHODS:
-            return request.user.is_authenticated
-        else:
-            return isinstance(request.user, SluglineUser) and request.user.at_least(
-                EDITOR_GROUP
-            )
+        return article.user == request.user

--- a/content/views.py
+++ b/content/views.py
@@ -18,9 +18,9 @@ from content.serializers import (
     ArticleContentSerializer,
 )
 from common.permissions import (
+    create_permission,
     IsCopyeditorOrAbove,
     IsEditor,
-    create_permission,
     IsAuthenticated,
 )
 from content.permissions import (

--- a/content/views.py
+++ b/content/views.py
@@ -7,7 +7,6 @@ from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet, GenericViewSet, ReadOnlyModelViewSet
 from rest_framework.mixins import ListModelMixin, RetrieveModelMixin, UpdateModelMixin
 from rest_framework.decorators import action
-from rest_framework.permissions import IsAuthenticated, SAFE_METHODS
 
 from common.filters import SearchableFilterBackend
 from common.pagination import SluglinePagination
@@ -18,11 +17,16 @@ from content.serializers import (
     ArticleSerializer,
     ArticleContentSerializer,
 )
-from content.permissions import (
-    IsPublishedOrIsAuthenticated,
-    IsEditorOrIsAuthenticatedReadOnly,
+from common.permissions import (
+    IsCopyeditorOrAbove,
+    IsEditor,
+    create_permission,
+    IsAuthenticated,
 )
-from user.models import SluglineUser
+from content.permissions import (
+    IsArticleOwner,
+    IsArticlePublished,
+)
 
 
 def transform_issue_name(term):
@@ -48,7 +52,9 @@ class IssueViewSet(ModelViewSet):
 
     __articles_filter = SearchableFilterBackend(["title", "content_raw"])
 
-    permission_classes = [IsEditorOrIsAuthenticatedReadOnly]
+    permission_classes = [
+        create_permission(read_perm=IsAuthenticated, write_perm=IsEditor)
+    ]
 
     @action(detail=False, methods=["GET"])
     def latest(self, request):
@@ -91,19 +97,14 @@ class PublishedIssueViewSet(ReadOnlyModelViewSet):
 
 
 class ArticleViewSet(ModelViewSet):
-    class ArticlePermissions(IsPublishedOrIsAuthenticated):
-        def has_object_permission(self, request, view, article):
-            if request.method in SAFE_METHODS:
-                return super().has_object_permission(request, view, article)
-            else:
-                return isinstance(request.user, SluglineUser) and (
-                    article.user == request.user
-                    or request.user.at_least(COPYEDITOR_GROUP)
-                )
-
     queryset = Article.objects.all()
     serializer_class = ArticleSerializer
-    permission_classes = [ArticlePermissions]
+    permission_classes = [
+        create_permission(
+            read_perm=IsArticlePublished | IsAuthenticated,
+            write_perm=IsArticleOwner | IsCopyeditorOrAbove,
+        )
+    ]
     filter_backends = [SearchableFilterBackend]
     search_fields = ["title", "content_raw"]
     search_transformers = {"is": "status"}
@@ -132,10 +133,10 @@ class UserArticleViewSet(GenericViewSet, ListModelMixin, RetrieveModelMixin):
 class ArticleContentViewSet(GenericViewSet, RetrieveModelMixin, UpdateModelMixin):
     queryset = Article.objects.all()
     serializer_class = ArticleContentSerializer
-    permission_classes = [IsPublishedOrIsAuthenticated]
+    permission_classes = [IsArticlePublished | IsAuthenticated]
 
 
 class ArticleHTMLViewSet(GenericViewSet, RetrieveModelMixin):
     queryset = Article.objects.all()
     serializer_class = ArticleContentSerializer
-    permission_classes = [IsPublishedOrIsAuthenticated]
+    permission_classes = [IsArticlePublished | IsAuthenticated]


### PR DESCRIPTION
This PR refactors the permission system to prevent the combinatorial explosion of permission classes we had earlier.

Instead, it introduces a new function `create_permission(read_perm, write_perm)` that allows read permission and write permissions to be specified separately. It also uses DRF's composable permissions to avoid writing one off `XorY` permission classes.

This comes with one caveat: DRF's standard permission classes do not handle `has_object_permission` well when composing. Instead, the new permissions are based on our own `BasePermission`. DRF's default permission classes should no longer be used.